### PR TITLE
Logs errors and exceptions to TA log file (_internal index)

### DIFF
--- a/bin/input_module_jamfcomputers.py
+++ b/bin/input_module_jamfcomputers.py
@@ -118,6 +118,7 @@ def collect_events(helper, ew):
 
         if index is not None:
             event = helper.new_event(data=json.dumps(thisEvent, ensure_ascii=False), source=source, time=eventTime,
+                                     index=index,
                                      host=host,
                                      sourcetype=sourcetype)
         else:
@@ -141,8 +142,7 @@ def collect_events(helper, ew):
                     'operator': '>'
                 }
             except:
-                errors.append(
-                    {'type': 'Filter Value Error', 'value': settings['computerCollection']['daysSinceContact']})
+                helper.log_error("Error applying filter=daysSinceContact with value=%s please check TA configuration and ensure that daysSinceContact is configured with a positive integer value" % settings['computerCollection']['daysSinceContact'])
 
         sections = settings['computerCollection']['sections']
 
@@ -196,4 +196,4 @@ def collect_events(helper, ew):
                         "sourcetype": "jamf:jssInventory:errorCode"
                     }
 
-                    writeEvent(error_event)
+                    helper.log_error("An error occured while processing a jamf computer object with jss_id=%s from jss_url=%s" % (computer['id'], settings['jamfSettings']['jssUrl']))

--- a/bin/uapiModels/jamfpro.py
+++ b/bin/uapiModels/jamfpro.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import requests
 import base64
+from splunklib.modularinput import helper
 
 class JamfPro:
     class JamfUAPIAuthToken(object):
@@ -155,20 +156,20 @@ class JamfPro:
         :return:
         """
         url = URL
-        respons_content = None
+        request_successful = None
         for i in range(0, 3):
             try:
-                if respons_content is None:
+                if request_successful:
                     response = self.helper.send_http_request(url="https://" + url,
                                                              method="GET", payload=None,
                                                              headers=self.getXMLHeaders, verify=True,
                                                              use_proxy=self.useProxy, timeout=60)
                     if response.status_code == "200" or response.status_code == 200:
-                        respons_content = "something"
+                        request_successful = True
                         return response
             except Exception as e:
-                print(e)
-                respons_content = None
+                helper.log_error("Exception occured when making request to URL=%s\n%s" % (URL, e))
+                request_successful = None
 
         return response
 

--- a/local/props.conf
+++ b/local/props.conf
@@ -1,5 +1,5 @@
 [Jamf]
-TRUNCATE = 90000
+TRUNCATE = 100000
 SHOULD_LINEMERGE = 0
 category = Splunk App Add-on Builder
 pulldown_type = 1
@@ -7,12 +7,12 @@ pulldown_type = 1
 [JamfModularInput]
 DATETIME_CONFIG = NONE
 KV_MODE = xml
-TRUNCATE = 90000
+TRUNCATE = 100000
 category = Splunk App Add-on Builder
 pulldown_type = 1
 
 [JamfMobileDevices]
 SHOULD_LINEMERGE = 0
+TRUNCATE = 100000
 category = Splunk App Add-on Builder
 pulldown_type = 1
-


### PR DESCRIPTION
The changes proposed in this PR are intended to accomplish the following:
 - Increase the maximum event size (maxCharLength) which requires corresponding props.conf changes to avoid truncation
 - All errors and exceptions are now logged to the TA log which is forwarded to the _internal index by default, they are no longer forwarded to the event index as event data
 - Small fix in specifying index parameter to event_writer method in EventWriter method

Note: Writing TA errors and exceptions to the TA log and not as event data is a best practice; failure to do this adversely impacts thruput metrics in metrics.log by making it appear that the forwarder running the TA is indexing event data when in fact it may only be indexing errors and exceptions from the TA -- this interferes with the healthcheck logic used by the following project: https://github.com/splunk/docker-swarm-splunk-hf